### PR TITLE
Gracefully handle missing position_id by outputing an error and exiting.

### DIFF
--- a/etoro_edavki.py
+++ b/etoro_edavki.py
@@ -838,6 +838,11 @@ def main():
             rate = get_exchange_rate(rates, date, ETORO_CURRENCY)
             amount_eur = str2float(xlsTransaction.amount) / rate
 
+            if (openPositions.get(position_id) == None):
+                print("!!! POZOR / NAPAKA: Ključa [position_id={0}] ni v slovarju [openPositions]!".format(position_id))
+                print("                    Verjetno vhodna datoteka ne zajema ceotnega obdobja obdelanih finančnih instrumentov.")
+                sys.exit(1)
+
             open_pos = openPositions[position_id]
             symbol = open_pos["symbol"]
 


### PR DESCRIPTION
Izpis smiselne napake za manjkujočo pozicijo - npr. če vhodna datoteka ne vključuje vseh transakcij (začetnih) pozicij za opazovano obdobje (leto).