### PR TITLE
Update etoro_edavki.py - process also ISIN column from the .xlsx file

### DIFF
--- a/etoro_edavki.py
+++ b/etoro_edavki.py
@@ -80,7 +80,7 @@ class ClosedPositionsSheet(TableSheet):
     overnight_fees_and_dividends = CharColumn(header="Overnight Fees and Dividends")
     trader = CharColumn(header="Copied From")
     type = CharColumn(header="Type")
-    #isin = CharColumn(header="ISIN")
+    isin = CharColumn(header="ISIN")
     notes = CharColumn(header="Notes")
 
 class AccountActivityReportSheet(TableSheet):


### PR DESCRIPTION
On 24.Feb exported Account Statement from eToro contains ISIN column which has to be taken into account in the code to avoid the following error: openpyxl_templates.table_sheet.table_sheet.HeadersNotFound

Once line 83 uncommented, the program successfully parsed the .xlsx input file and created files in the output folder: D-IFI.xml, Debug-2024.xlsx, Dividende-info-2024.xlsx, Doh-Div.xml, Doh-KDVP.xml